### PR TITLE
Add more frequency methods

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -98,7 +98,7 @@ There are a number of ways available to specify how often the task is called.
 |:------------------------------|:----------------------------------------------------------------------|
 | ->cron('* * * * *')           | Run on a custom cron schedule.                                        |
 | ->daily('4:00 am')            | Runs daily at 12:00am, unless a time string is passed in.             |    
-| ->hourly()                    | Runs at the top of every hour.                                        |
+| ->hourly() / ->hourly(15)     | Runs at the top of every hour or at specified minute.                 |
 | ->everyFiveMinutes()          | Runs every 5 minutes (12:00, 12:05, 12:10, etc)                       |
 | ->everyFifteenMinutes()       | Runs every 15 minutes (12:00, 12:15, etc)                             |
 | ->everyThirtyMinutes()        | Runs every 30 minutes (12:00, 12:30, etc)                             |
@@ -115,6 +115,17 @@ There are a number of ways available to specify how often the task is called.
 | ->weekdays('1:23pm')          | Runs M-F at 12:00 am unless time passed in.                           |
 | ->weekends('2:34am')          | Runs Saturday and Sunday at 12:00 am unless time passed in.           |
 | ->environments('local', 'prod')   | Restricts the task to run only in the specified environments      |
+| ->everyHour(3, 15)            | Runs every 3 hours at XX:15.                                          |
+| ->betweenHours(6,12)          | Runs between hours 6 and 12.                                          |
+| ->hours([0,10,16])            | Runs at hours 0, 10 and 16.                                           |
+| ->everyMinute(20)             | Runs every 20 minutes.                                                |
+| ->betweenMinutes(0,30)        | Runs between minutes 0 and 30.                                        |
+| ->minutes([0,20,40])          | Runs at specific minutes 0,20 and 40.                                 |
+| ->days([0,3])                 | Runs only on Sunday and Wednesday  ( 0 is Sunday , 6 is Saturday )    |
+| ->daysOfMonth([1,15])         | Runs only on days 1 and 15.                                           |
+| ->months([1,7])               | Runs only on January and July.                                        |
+
+
 
 These methods can be combined to create even more nuanced timings: 
 

--- a/src/FrequenciesTrait.php
+++ b/src/FrequenciesTrait.php
@@ -79,14 +79,75 @@ trait FrequenciesTrait
 	}
 
 	/**
-	 * Runs at the top of every hour.
+	 * Runs at the top of every hour or at a specific minute.
 	 *
 	 * @return $this
 	 */
-	public function hourly()
+	public function hourly(int $minute = null)
 	{
-		$this->expression['min']  = '00';
+		$this->expression['min']  = is_null($minute) ? "00" : $minute;
 		$this->expression['hour'] = '*';
+
+		return $this;
+	}
+
+
+	/**
+	 * Runs at every hour or every x hours
+	 *
+	 * @param int  $hour
+	 * @param null $minute
+	 * @return self
+	 */
+	public function everyHour(int $hour = 1, $minute = null)
+	{
+		$this->expression['min'] = is_null($minute) ? "0" : $minute;
+		$this->expression['hour'] = ($hour == 1) ? "*" : '*/' . $hour;
+
+		return $this;
+	}
+
+	/**
+	 * Runs in a specific range of hours
+	 *
+	 * @param int $fromHour
+	 * @param int $toHour
+	 * @return self
+	 */
+	public function betweenHours(int $fromHour, int $toHour)
+	{
+		$this->expression['hour'] = $fromHour . "-" . $toHour;
+		return $this;
+	}
+
+	/**
+	 * Runs on a specific choosen hours
+	 *
+	 * @param array $hours
+	 * @return self
+	 */
+	public function hours(array $hours = [])
+	{
+		if (!is_array($hours))
+		{
+			$hours = [$hours];
+		}
+
+		$this->expression['hour'] = implode(",", $hours);
+
+		return $this;
+	}
+
+	/**
+	 * Set the execution time to every minute or every x minutes.
+	 *
+	 * @param int|string|null When set, specifies that the job will be run every $minute minutes
+	 *
+	 * @return self
+	 */
+	public function everyMinute($minute = null)
+	{
+		$this->expression['min'] = is_null($minute) ? "*" : '*/' . $minute;
 
 		return $this;
 	}
@@ -98,10 +159,7 @@ trait FrequenciesTrait
 	 */
 	public function everyFiveMinutes()
 	{
-		$this->expression['min']  = '/5';
-		$this->expression['hour'] = '*';
-
-		return $this;
+		return $this->everyMinute(5);
 	}
 
 	/**
@@ -111,10 +169,7 @@ trait FrequenciesTrait
 	 */
 	public function everyFifteenMinutes()
 	{
-		$this->expression['min']  = '/15';
-		$this->expression['hour'] = '*';
-
-		return $this;
+		return $this->everyMinute(15);
 	}
 
 	/**
@@ -124,8 +179,56 @@ trait FrequenciesTrait
 	 */
 	public function everyThirtyMinutes()
 	{
-		$this->expression['min']  = '/30';
-		$this->expression['hour'] = '*';
+		return $this->everyMinute(30);
+	}
+
+
+	/**
+	 * Runs in a specific range of minutes
+	 *
+	 * @param int $fromMinute
+	 * @param int $toMinute
+	 * @return self
+	 */
+	public function betweenMinutes(int $fromMinute,int $toMinute)
+	{
+		$this->expression['min'] = $fromMinute . "-" . $toMinute;
+		return $this;
+	}
+
+	/**
+	 * Runs on a specific choosen minutes
+	 *
+	 * @param array $minutes
+	 * @return self
+	 */
+	public function minutes(array $minutes = [])
+	{
+		if (!is_array($minutes))
+		{
+			$minutes = [$minutes];
+		}
+
+		$this->expression['min'] = implode(",", $minutes);
+
+		return $this;
+	}
+
+
+	/**
+	 * Runs on specific days
+	 *
+	 * @param array|int $days [0 : Sunday - 6 : Saturday]
+	 * @return self
+	 */
+	public function days($days)
+	{
+		if (!is_array($days))
+		{
+			$days = [$days];
+		}
+
+		$this->expression['dayOfWeek'] = implode(",", $days);
 
 		return $this;
 	}
@@ -238,6 +341,36 @@ trait FrequenciesTrait
 	}
 
 	/**
+	 * Runs on specific days of the month
+	 *
+	 * @param array|int $days [1-31]
+	 * @return self
+	 */
+	public function daysOfMonth($days)
+	{
+		if (!is_array($days))
+		{
+			$days = [$days];
+		}
+
+		$this->expression['dayOfMonth'] = implode(",", $days);
+
+		return $this;
+	}
+
+	/**
+	 * Runs on specific months
+	 *
+	 * @param array $months
+	 * @return self
+	 */
+	public function months(array $months = [])
+	{
+		$this->expression['month'] = implode(",", $months);
+		return $this;
+	}
+
+	/**
 	 * Should run the first day of each quarter,
 	 * i.e. Jan 1, Apr 1, July 1, Oct 1
 	 *
@@ -331,6 +464,7 @@ trait FrequenciesTrait
 
 		return $this;
 	}
+
 
 	/**
 	 * Internal function used by the everyMonday, etc functions.

--- a/src/FrequenciesTrait.php
+++ b/src/FrequenciesTrait.php
@@ -390,7 +390,7 @@ trait FrequenciesTrait
 		$this->expression['min']        = $min;
 		$this->expression['hour']       = $hour;
 		$this->expression['dayOfMonth'] = 1;
-		$this->expression['month']      = '/3';
+		$this->expression['month']      = '*/3';
 
 		return $this;
 	}

--- a/tests/unit/FrequenciesTraitTest.php
+++ b/tests/unit/FrequenciesTraitTest.php
@@ -4,233 +4,328 @@ use CodeIgniter\Test\CIUnitTestCase as TestCase;
 
 class FrequenciesTraitTest extends TestCase
 {
-    protected $class;
+	protected $class;
 
-    public function setUp(): void
-    {
-        parent::setUp();
+	public function setUp(): void
+	{
+		parent::setUp();
 
-        $this->class = new class() {
-            use \CodeIgniter\Tasks\FrequenciesTrait;
-        };
-    }
+		$this->class = new class() {
+			use \CodeIgniter\Tasks\FrequenciesTrait;
+		};
+	}
 
-    public function testSetCron()
-    {
-        $cron = '5 10 11 12 6';
+	public function testSetCron()
+	{
+		$cron = '5 10 11 12 6';
 
-        $this->class->cron($cron);
+		$this->class->cron($cron);
 
-        $this->assertEquals($cron, $this->class->getExpression());
-    }
+		$this->assertEquals($cron, $this->class->getExpression());
+	}
 
-    public function testDaily()
-    {
-        $this->class->daily();
+	public function testDaily()
+	{
+		$this->class->daily();
 
-        $this->assertEquals('0 0 * * *', $this->class->getExpression());
-    }
+		$this->assertEquals('0 0 * * *', $this->class->getExpression());
+	}
 
-    public function testDailyWithTime()
-    {
-        $this->class->daily('4:08 pm');
+	public function testDailyWithTime()
+	{
+		$this->class->daily('4:08 pm');
 
-        $this->assertEquals('08 16 * * *', $this->class->getExpression());
-    }
+		$this->assertEquals('08 16 * * *', $this->class->getExpression());
+	}
 
-    public function testHourly()
-    {
-        $this->class->hourly();
+	public function testHourly()
+	{
+		$this->class->hourly();
 
-        $this->assertEquals('00 * * * *', $this->class->getExpression());
-    }
+		$this->assertEquals('00 * * * *', $this->class->getExpression());
+	}
 
-    public function testEveryFiveMinutes()
-    {
-        $this->class->everyFiveMinutes();
+	public function testHourlyWithMinutes()
+	{
+		$this->class->hourly(30);
 
-        $this->assertEquals('/5 * * * *', $this->class->getExpression());
-    }
+		$this->assertEquals('30 * * * *', $this->class->getExpression());
+	}
 
-    public function testEveryFifteenMinutes()
-    {
-        $this->class->everyFifteenMinutes();
+	public function testEveryFiveMinutes()
+	{
+		$this->class->everyFiveMinutes();
 
-        $this->assertEquals('/15 * * * *', $this->class->getExpression());
-    }
+		$this->assertEquals('*/5 * * * *', $this->class->getExpression());
+	}
 
-    public function testEveryThirtyMinutes()
-    {
-        $this->class->everyThirtyMinutes();
+	public function testEveryFifteenMinutes()
+	{
+		$this->class->everyFifteenMinutes();
 
-        $this->assertEquals('/30 * * * *', $this->class->getExpression());
-    }
+		$this->assertEquals('*/15 * * * *', $this->class->getExpression());
+	}
 
-    public function testEverySunday()
-    {
-        $this->class->sundays();
+	public function testEveryThirtyMinutes()
+	{
+		$this->class->everyThirtyMinutes();
 
-        $this->assertEquals('* * * * 0', $this->class->getExpression());
-    }
+		$this->assertEquals('*/30 * * * *', $this->class->getExpression());
+	}
 
-    public function testEverySundayWithTime()
-    {
-        $this->class->sundays('4:08 pm');
+	public function testEverySunday()
+	{
+		$this->class->sundays();
 
-        $this->assertEquals('08 16 * * 0', $this->class->getExpression());
-    }
+		$this->assertEquals('* * * * 0', $this->class->getExpression());
+	}
 
-    public function testEveryMonday()
-    {
-        $this->class->mondays();
+	public function testEverySundayWithTime()
+	{
+		$this->class->sundays('4:08 pm');
 
-        $this->assertEquals('* * * * 1', $this->class->getExpression());
-    }
+		$this->assertEquals('08 16 * * 0', $this->class->getExpression());
+	}
 
-    public function testEveryMondayWithTime()
-    {
-        $this->class->mondays('4:08 pm');
+	public function testEveryMonday()
+	{
+		$this->class->mondays();
 
-        $this->assertEquals('08 16 * * 1', $this->class->getExpression());
-    }
+		$this->assertEquals('* * * * 1', $this->class->getExpression());
+	}
 
-    public function testEveryTuesday()
-    {
-        $this->class->tuesdays();
+	public function testEveryMondayWithTime()
+	{
+		$this->class->mondays('4:08 pm');
 
-        $this->assertEquals('* * * * 2', $this->class->getExpression());
-    }
+		$this->assertEquals('08 16 * * 1', $this->class->getExpression());
+	}
 
-    public function testEveryTuesdayWithTime()
-    {
-        $this->class->tuesdays('4:08 pm');
+	public function testEveryTuesday()
+	{
+		$this->class->tuesdays();
 
-        $this->assertEquals('08 16 * * 2', $this->class->getExpression());
-    }
+		$this->assertEquals('* * * * 2', $this->class->getExpression());
+	}
 
-    public function testEveryWednesday()
-    {
-        $this->class->wednesdays();
+	public function testEveryTuesdayWithTime()
+	{
+		$this->class->tuesdays('4:08 pm');
 
-        $this->assertEquals('* * * * 3', $this->class->getExpression());
-    }
+		$this->assertEquals('08 16 * * 2', $this->class->getExpression());
+	}
 
-    public function testEveryWednesdayWithTime()
-    {
-        $this->class->wednesdays('4:08 pm');
+	public function testEveryWednesday()
+	{
+		$this->class->wednesdays();
 
-        $this->assertEquals('08 16 * * 3', $this->class->getExpression());
-    }
+		$this->assertEquals('* * * * 3', $this->class->getExpression());
+	}
 
-    public function testEveryThursday()
-    {
-        $this->class->thursdays();
+	public function testEveryWednesdayWithTime()
+	{
+		$this->class->wednesdays('4:08 pm');
 
-        $this->assertEquals('* * * * 4', $this->class->getExpression());
-    }
+		$this->assertEquals('08 16 * * 3', $this->class->getExpression());
+	}
 
-    public function testEveryThursdayWithTime()
-    {
-        $this->class->thursdays('4:08 pm');
+	public function testEveryThursday()
+	{
+		$this->class->thursdays();
 
-        $this->assertEquals('08 16 * * 4', $this->class->getExpression());
-    }
+		$this->assertEquals('* * * * 4', $this->class->getExpression());
+	}
 
-    public function testEveryFriday()
-    {
-        $this->class->fridays();
+	public function testEveryThursdayWithTime()
+	{
+		$this->class->thursdays('4:08 pm');
 
-        $this->assertEquals('* * * * 5', $this->class->getExpression());
-    }
+		$this->assertEquals('08 16 * * 4', $this->class->getExpression());
+	}
 
-    public function testEveryFridayWithTime()
-    {
-        $this->class->fridays('4:08 pm');
+	public function testEveryFriday()
+	{
+		$this->class->fridays();
 
-        $this->assertEquals('08 16 * * 5', $this->class->getExpression());
-    }
+		$this->assertEquals('* * * * 5', $this->class->getExpression());
+	}
 
-    public function testEverySaturday()
-    {
-        $this->class->saturdays();
+	public function testEveryFridayWithTime()
+	{
+		$this->class->fridays('4:08 pm');
 
-        $this->assertEquals('* * * * 6', $this->class->getExpression());
-    }
+		$this->assertEquals('08 16 * * 5', $this->class->getExpression());
+	}
 
-    public function testEverySaturdayWithTime()
-    {
-        $this->class->saturdays('4:08 pm');
+	public function testEverySaturday()
+	{
+		$this->class->saturdays();
 
-        $this->assertEquals('08 16 * * 6', $this->class->getExpression());
-    }
+		$this->assertEquals('* * * * 6', $this->class->getExpression());
+	}
 
-    public function testMonthly()
-    {
-        $this->class->monthly();
+	public function testEverySaturdayWithTime()
+	{
+		$this->class->saturdays('4:08 pm');
 
-        $this->assertEquals('0 0 1 * *', $this->class->getExpression());
-    }
+		$this->assertEquals('08 16 * * 6', $this->class->getExpression());
+	}
 
-    public function testMonthlyWithTime()
-    {
-        $this->class->monthly('4:08 pm');
+	public function testMonthly()
+	{
+		$this->class->monthly();
 
-        $this->assertEquals('08 16 1 * *', $this->class->getExpression());
-    }
+		$this->assertEquals('0 0 1 * *', $this->class->getExpression());
+	}
 
-    public function testYearly()
-    {
-        $this->class->yearly();
+	public function testMonthlyWithTime()
+	{
+		$this->class->monthly('4:08 pm');
 
-        $this->assertEquals('0 0 1 1 *', $this->class->getExpression());
-    }
+		$this->assertEquals('08 16 1 * *', $this->class->getExpression());
+	}
 
-    public function testYearlyWithTime()
-    {
-        $this->class->yearly('4:08 pm');
+	public function testYearly()
+	{
+		$this->class->yearly();
 
-        $this->assertEquals('08 16 1 1 *', $this->class->getExpression());
-    }
+		$this->assertEquals('0 0 1 1 *', $this->class->getExpression());
+	}
 
-    public function testQuarterly()
-    {
-        $this->class->quarterly();
+	public function testYearlyWithTime()
+	{
+		$this->class->yearly('4:08 pm');
 
-        $this->assertEquals('0 0 1 /3 *', $this->class->getExpression());
-    }
+		$this->assertEquals('08 16 1 1 *', $this->class->getExpression());
+	}
 
-    public function testQuarterlyWithTime()
-    {
-        $this->class->quarterly('4:08 pm');
+	public function testQuarterly()
+	{
+		$this->class->quarterly();
 
-        $this->assertEquals('08 16 1 /3 *', $this->class->getExpression());
-    }
+		$this->assertEquals('0 0 1 */3 *', $this->class->getExpression());
+	}
 
-    public function testWeekdays()
-    {
-        $this->class->weekdays();
+	public function testQuarterlyWithTime()
+	{
+		$this->class->quarterly('4:08 pm');
 
-        $this->assertEquals('0 0 * * 1-5', $this->class->getExpression());
-    }
+		$this->assertEquals('08 16 1 */3 *', $this->class->getExpression());
+	}
 
-    public function testWeekdaysWithTime()
-    {
-        $this->class->weekdays('4:08 pm');
+	public function testWeekdays()
+	{
+		$this->class->weekdays();
 
-        $this->assertEquals('08 16 * * 1-5', $this->class->getExpression());
-    }
+		$this->assertEquals('0 0 * * 1-5', $this->class->getExpression());
+	}
 
-    public function testWeekends()
-    {
-        $this->class->weekends();
+	public function testWeekdaysWithTime()
+	{
+		$this->class->weekdays('4:08 pm');
 
-        $this->assertEquals('0 0 * * 6-7', $this->class->getExpression());
-    }
+		$this->assertEquals('08 16 * * 1-5', $this->class->getExpression());
+	}
 
-    public function testWeekendsWithTime()
-    {
-        $this->class->weekends('4:08 pm');
+	public function testWeekends()
+	{
+		$this->class->weekends();
 
-        $this->assertEquals('08 16 * * 6-7', $this->class->getExpression());
-    }
+		$this->assertEquals('0 0 * * 6-7', $this->class->getExpression());
+	}
+
+	public function testWeekendsWithTime()
+	{
+		$this->class->weekends('4:08 pm');
+
+		$this->assertEquals('08 16 * * 6-7', $this->class->getExpression());
+	}
+
+
+	public function testEveryHour()
+	{
+		$this->class->everyHour();
+
+		$this->assertEquals('0 * * * *', $this->class->getExpression());
+	}
+
+	public function testEveryHourWithHour()
+	{
+		$this->class->everyHour(3);
+
+		$this->assertEquals('0 */3 * * *', $this->class->getExpression());
+	}
+
+	public function testEveryHourWithHourAndMinutes()
+	{
+		$this->class->everyHour(3,15);
+
+		$this->assertEquals('15 */3 * * *', $this->class->getExpression());
+	}
+
+	public function testBetweenHours()
+	{
+		$this->class->betweenHours(10,12);
+
+		$this->assertEquals('* 10-12 * * *', $this->class->getExpression());
+	}
+
+	public function testHours()
+	{
+		$this->class->hours([12,16]);
+
+		$this->assertEquals('* 12,16 * * *', $this->class->getExpression());
+	}
+
+	public function testEveryMinute()
+	{
+		$this->class->everyMinute();
+
+		$this->assertEquals('* * * * *', $this->class->getExpression());
+	}
+
+	public function testEveryMinuteWithParameter()
+	{
+		$this->class->everyMinute(15);
+
+		$this->assertEquals('*/15 * * * *', $this->class->getExpression());
+	}
+
+	public function testBetweenMinutes()
+	{
+		$this->class->betweenMinutes(15,30);
+
+		$this->assertEquals('15-30 * * * *', $this->class->getExpression());
+	}
+
+	public function testMinutes()
+	{
+		$this->class->minutes([0,10,30]);
+
+		$this->assertEquals('0,10,30 * * * *', $this->class->getExpression());
+	}
+
+	public function testDays()
+	{
+		$this->class->days([0,4]);
+
+		$this->assertEquals('* * * * 0,4', $this->class->getExpression());
+	}
+
+
+	public function testDaysOfMonth()
+	{
+		$this->class->daysOfMonth([1,15]);
+
+		$this->assertEquals('* * 1,15 * *', $this->class->getExpression());
+	}
+
+
+	public function testMonths()
+	{
+		$this->class->months([1, 7]);
+
+		$this->assertEquals('* * * 1,7 *', $this->class->getExpression());
+	}
+
 }


### PR DESCRIPTION
I already have my own codeigniter-tasks package which includes all the points mentioned in this repo's vision (including performance commands) and I would like to participate in completing this repo.

I will start my pull requests in batches ( for easy review ) depending on the quick response from the maintainers.

My first pull request will be adding missing frequency methods which i think are very useful.

**Changed Methods are:**
1) hourly() : I think it's better to add minutes as an optional parameter to specify the exact minute instead of setting it to zero by default.
```php
 $schedule->hourly();        // Will Run hour at xx:00
 $schedule->hourly(15);    // Will Run hour at xx:15
```

**New Methods are:**
1) everyHour(hour = 1, minute = null)
This method is useful for scheduling jobs to run every x hours. if minute is not passed it will be set to zero.
```php
 $schedule->everyHour(3) // Will Run Every 3 hours at xx:00
 $schedule->everyHour(3,15) // Will Run Every 3 hours at xx:15
```

2) betweenHours(from , to)
Run the task between specific hours by using pure cron expression (from-to).
```php
 $schedule->betweenHours(6,10)  // Will run between hours 6 and 10
```

3) hours( array[] )
Run the task at specific hours passed as an array. Time should be passed by at() method.
```php
 $schedule->hours( [12,16] )  // Will run on hour 12 and on hour 16.
```

4) everyMinute( minute = null )
This method is useful for scheduling jobs to run every x minutes. if minute is not passed it will be set to * (every minute).
```php
 $schedule->everyMinute() // Will run every minute
 $schedule->everyMinute(20) // Will run every 20 minutes
```
This method changed the implementation for the following methods everyFiveMinutes(),everyFifteenMinutes() and everyThirtyMinutes().

5) betweenMinutes(from , to)
Run the task between specific minutes by using pure cron expression (from-to).
```php
 $schedule->betweenMinutes(15,30)  // Will run between minutes 15 and 30
```

6) minutes( array[] )
Run the task at specific minutes passed as an array.
```php
 $schedule->minutes( [0,10,30] )  // Will run on minutes 0, 10 and 30
```

7) days( array[] )
Run the task at specific days passed as an array. as per cron specifications 0 is sunday and 6 is saturday
```php
 $schedule->days( [0,4] )  // Will run on Sunday and Thursday
```

8) daysOfMonth( array[] )
Run the task at specific days of the month passed as an array.
```php
 $schedule->daysOfMonth( [1,15] )  // Will run on day 1 and day 15
```

9) months( array[] )
Run the task at specific month passed as an array.
```php
 $schedule->months( [1,7] )  // Will run on January and July
```

**In Addition, I think the following should be added to the vision of this repo :**

1) Task's callbacks should be added (after, before, onSuccess, onFailure) which are very important and very useful.
```php
$schedule->call( function(){  /* Some Code */ } )
     ->before( function() {
               // Do Something
         })
     ->after( function( $output ) {
               // Do Something
         })
     ->onSuccess( function() {
               // Do Something
         })
     ->oFailure( function() {
               // Do Something
         });
```
2) Overlapping Option, to avoid running multiple instances of the same task using locks files.
```php
$schedule->call( function(){  /* Some Code */ } )
     ->onlyOne();
```