### PR TITLE
Remove Offset

### DIFF
--- a/src/FrequenciesTrait.php
+++ b/src/FrequenciesTrait.php
@@ -436,7 +436,7 @@ trait FrequenciesTrait
 
         $this->expression['min']       = $min;
         $this->expression['hour']      = $hour;
-        $this->expression['dayOfWeek'] = $day + 1; //cron uses 0 based day of week (0 is Sunday), but this functions with (1 as Sunday)
+        $this->expression['dayOfWeek'] = $day;
 
         return $this;
     }


### PR DESCRIPTION
I am not sure why the offset was there - it is deliberate (according to the code comment) but the expected test values are precisely what they should be and this offset is causing them to fail.

Compared with https://crontab.cronhub.io