### PR TITLE
Rename Package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "codeigniter4-projects/tasks",
+    "name": "codeigniter4/tasks",
     "type": "library",
     "description": "Task Scheduler for CodeIgniter 4",
     "keywords": [
@@ -8,7 +8,7 @@
         "task scheduling",
         "cron"
     ],
-    "homepage": "https://github.com/codeigniter4-projects/codeigniter4-tasks",
+    "homepage": "https://github.com/codeigniter4/tasks",
     "license": "MIT",
     "authors": [
         {


### PR DESCRIPTION
Following `Settings` and `Cache` this updates the package and repository to use the `CodeIgniter4` organization. We have some planning and reorganizing to do but thus far `codeigniter4projects` (no dash) appears to be for projects created using the framework, whereas official packages/modules have been heading to the main org.

If this change seems amenable perhaps @lonnieezell would also consider moving this repo to grant the team access 🤗

***

Note: I have left the namespace `CodeIgniter` for now - we have some packages using `Sparks` but it isn't consistent enough yet to mandate a sweeping change.
