### PR TITLE
fix: $output of type ?string

### DIFF
--- a/src/Task.php
+++ b/src/Task.php
@@ -230,12 +230,12 @@ class Task
 
     /**
      * Triggers an Event.
-     *
-     * @return bool Result of the trigger
      */
-    protected function runEvent(): bool
+    protected function runEvent(): string
     {
-        return Events::trigger($this->getAction());
+        $event = Events::trigger($this->getAction());
+
+        return $event ? "true" : "false";
     }
 
     /**

--- a/src/Task.php
+++ b/src/Task.php
@@ -112,10 +112,8 @@ class Task
      * Runs this Task's action.
      *
      * @throws TasksException
-     *
-     * @return mixed
      */
-    public function run()
+    public function run(): ?string
     {
         $method = 'run' . ucfirst($this->type);
         if (! method_exists($this, $method)) {
@@ -212,14 +210,12 @@ class Task
 
     /**
      * Executes a shell script.
-     *
-     * @return array Lines of output from exec
      */
-    protected function runShell(): array
+    protected function runShell(): ?string
     {
         exec($this->getAction(), $output);
 
-        return $output;
+        return empty($output) ? null : json_encode($output);
     }
 
     /**

--- a/src/TaskLog.php
+++ b/src/TaskLog.php
@@ -8,14 +8,14 @@ use Throwable;
 
 /**
  * @property ?Throwable $error
- * @property ?string    $output
+ * @property ?array   $output
  * @property Time       $runStart
  * @property Task       $task
  */
 class TaskLog
 {
     protected Task $task;
-    protected ?string $output = null;
+    protected ?array $output = null;
     protected Time $runStart;
     protected Time $runEnd;
 

--- a/src/TaskLog.php
+++ b/src/TaskLog.php
@@ -8,7 +8,7 @@ use Throwable;
 
 /**
  * @property ?Throwable $error
- * @property ?array   $output
+ * @property ?array     $output
  * @property Time       $runStart
  * @property Task       $task
  */

--- a/src/TaskLog.php
+++ b/src/TaskLog.php
@@ -8,14 +8,14 @@ use Throwable;
 
 /**
  * @property ?Throwable $error
- * @property ?array     $output
+ * @property ?string    $output
  * @property Time       $runStart
  * @property Task       $task
  */
 class TaskLog
 {
     protected Task $task;
-    protected ?array $output = null;
+    protected ?string $output = null;
     protected Time $runStart;
     protected Time $runEnd;
 


### PR DESCRIPTION
Cannot assign array to property `CodeIgniter\Tasks\TaskLog::$output` of type `?string`

```php
CodeIgniter v4.2.4 Command Line Tool - Server Time: 2022-08-14 15:01:41 UTC+02:00

Running Tasks...
[2022-08-14 15:01:41] Processing: task1
[2022-08-14 15:01:41] Executed: task1

[TypeError]

Cannot assign array to property CodeIgniter\Tasks\TaskLog::$output of type ?string

at VENDORPATH/codeigniter4/tasks/src/TaskLog.php:34

Backtrace:
  1    VENDORPATH/codeigniter4/tasks/src/TaskRunner.php:74
       CodeIgniter\Tasks\TaskLog()->__construct([...])

  2    VENDORPATH/codeigniter4/tasks/src/Commands/Run.php:59
       CodeIgniter\Tasks\TaskRunner()->run()

  3    SYSTEMPATH/CLI/Commands.php:63
       CodeIgniter\Tasks\Commands\Run()->run([])

  4    SYSTEMPATH/CLI/CommandRunner.php:65
       CodeIgniter\CLI\Commands()->run('tasks:run', [])

  5    SYSTEMPATH/CLI/CommandRunner.php:51
       CodeIgniter\CLI\CommandRunner()->index([])

  6    SYSTEMPATH/CodeIgniter.php:897
       CodeIgniter\CLI\CommandRunner()->_remap('index', [...])

  7    SYSTEMPATH/CodeIgniter.php:457
       CodeIgniter\CodeIgniter()->runController(Object(CodeIgniter\CLI\CommandRunner))

  8    SYSTEMPATH/CodeIgniter.php:336
       CodeIgniter\CodeIgniter()->handleRequest(null, Object(Config\Cache), false)

  9    SYSTEMPATH/CLI/Console.php:48
       CodeIgniter\CodeIgniter()->run()

 10    ROOTPATH/spark:98
       CodeIgniter\CLI\Console()->run()

```