### PR TITLE
fix: phpstan errors

### DIFF
--- a/src/Commands/Run.php
+++ b/src/Commands/Run.php
@@ -43,7 +43,7 @@ class Run extends TaskCommand
             CLI::write(CLI::color('WARNING: Task running is currently disabled.', 'red'));
             CLI::write('To re-enable tasks run: tasks:enable');
 
-            return false;
+            return EXIT_ERROR;
         }
 
         CLI::write('Running Tasks...');
@@ -59,5 +59,7 @@ class Run extends TaskCommand
         $runner->run();
 
         CLI::write(CLI::color('Completed Running Tasks', 'green'));
+
+        return EXIT_SUCCESS;
     }
 }

--- a/src/TaskRunner.php
+++ b/src/TaskRunner.php
@@ -146,7 +146,9 @@ class TaskRunner
         }
 
         // Make sure we have room for one more
-        if ((is_countable($logs) ? count($logs) : 0) > setting('Tasks.maxLogsPerTask')) {
+        /** @var int $maxLogsPerTask */
+        $maxLogsPerTask = setting('Tasks.maxLogsPerTask');
+        if ((is_countable($logs) ? count($logs) : 0) > $maxLogsPerTask) {
             array_pop($logs);
         }
 


### PR DESCRIPTION
```
  ------ --------------------------------------------------------------------- 
  Line   src/Commands/Run.php                                                 
 ------ --------------------------------------------------------------------- 
  46     Method CodeIgniter\Tasks\Commands\Run::run() should return int|void  
         but returns false.                                                   
 ------ --------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------- 
  Line   src/TaskRunner.php                                                 
 ------ ------------------------------------------------------------------- 
  149    Comparison operation ">" between int<0, max> and                   
         array|bool|float|int|object|string|void|null results in an error.  
 ------ ------------------------------------------------------------------- 
```
https://github.com/codeigniter4/tasks/actions/runs/5144417787/jobs/9260690333