### PR TITLE
Bump to Rector 0.18.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require-dev": {
         "codeigniter4/devkit": "^1.0",
         "codeigniter4/framework": "^4.1",
-        "rector/rector": "0.17.14"
+        "rector/rector": "0.18.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION

Rector tagged 0.17.14 is removed and bump to 0.18.0 instead due to DI migration. This PR fix it to avoid error can't install Rector 0.17.14.