### PR TITLE
Fixed the WARNING: Task running is currently disabled. message appear…

### DIFF
--- a/src/Commands/Lister.php
+++ b/src/Commands/Lister.php
@@ -34,7 +34,7 @@ class Lister extends TaskCommand
     {
         helper('setting');
 
-        if (setting('Tasks.logPerformance') === false) {
+        if (setting('Tasks.enabled') === false) {
             CLI::write('WARNING: Task running is currently disabled.', 'red');
             CLI::write('To re-enable tasks run: tasks:enable');
             CLI::newLine();


### PR DESCRIPTION
Fixed the WARNING: Task running is currently disabled. message appearing even when tasks are enabled.

<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes #123).

-->
**Description**
This warning message is wrongfully displayed because the setting that's being check is Tasks.logPerformance instead of Tasks.enabled

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
