### PR TITLE
fix: publish command

### DIFF
--- a/src/Commands/Publish.php
+++ b/src/Commands/Publish.php
@@ -33,14 +33,11 @@ class Publish extends TaskCommand
         }
 
         foreach ($publisher->getPublished() as $file) {
-            $publisher->replace(
-                $file,
-                [
-                    'namespace CodeIgniter\\Tasks\\Config' => 'namespace Config',
-                    'use CodeIgniter\\Config\\BaseConfig'  => 'use CodeIgniter\\Tasks\\Config\\Tasks as BaseTasks',
-                    'class Tasks extends BaseConfig'       => 'class Tasks extends BaseTasks',
-                ]
-            );
+            $contents = file_get_contents($file);
+            $contents = str_replace('namespace CodeIgniter\\Tasks\\Config', 'namespace Config', $contents);
+            $contents = str_replace('use CodeIgniter\\Config\\BaseConfig', 'use CodeIgniter\\Tasks\\Config\\Tasks as BaseTasks', $contents);
+            $contents = str_replace('class Tasks extends BaseConfig', 'class Tasks extends BaseTasks', $contents);
+            file_put_contents($file, $contents);
         }
 
         CLI::write(CLI::color('  Published! ', 'green') . 'You can customize the configuration by editing the "app/Config/Tasks.php" file.');


### PR DESCRIPTION
**Description**
The `$publisher->replace()` method has been available since version 4.3.

Ref: https://codeigniter.com/user_guide/libraries/publisher.html#replace-string-file-array-replaces-bool

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
