### PR TITLE
doc: navigation

### DIFF
--- a/docs/assets/js/hljs.js
+++ b/docs/assets/js/hljs.js
@@ -1,3 +1,3 @@
-document.addEventListener('DOMContentLoaded', (event) => {
+window.document$.subscribe(() => {
     hljs.highlightAll();
 });

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,7 +28,6 @@ theme:
         name: Switch to light mode
   features:
     - navigation.instant
-    - navigation.instant.prefetch
     - content.code.copy
     - navigation.footer
     - content.action.edit

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,7 +55,7 @@ extra:
       link: https://join.slack.com/t/codeigniterchat/shared_invite/zt-244xrrslc-l_I69AJSi5y2a2RVN~xIdQ
       name: Slack
 
-
+site_url: https://tasks.codeigniter.com/
 repo_url: https://github.com/codeigniter4/tasks
 edit_uri: edit/develop/docs/
 copyright: Copyright &copy; 2023 CodeIgniter Foundation.


### PR DESCRIPTION
**Description**
This PR:

* adds `site_url`, to make `navigation.instant` feature work
* fixes the way `hljs` is initialized to work well with `navigation.instant` feature
* removes `navigation.instant.prefetch` feature because it's available only for sponsors of the MkDocs project

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
