### PR TITLE
refactor: add assert() for PHPStan

### DIFF
--- a/src/CronExpression.php
+++ b/src/CronExpression.php
@@ -142,6 +142,7 @@ class CronExpression
         }
 
         $currentTime = $this->testTime->format($format);
+        assert(ctype_digit($currentTime));
 
         // Handle repeating times (i.e. /5 or */5 for every 5 minutes)
         if (strpos($time, '/') !== false) {


### PR DESCRIPTION
**Description**
```
Error: Binary operation "%" between string and non-empty-string&numeric-string results in an error.
 ------ ------------------------------------------------------ 
  Line   src/CronExpression.php                                
 ------ ------------------------------------------------------ 
  154    Binary operation "%" between string and               
         non-empty-string&numeric-string results in an error.  
 ------ ------------------------------------------------------ 
```
https://github.com/codeigniter4/tasks/actions/runs/10093662663/job/27909864651?pr=171

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
