### PR TITLE
fix: unify the logged output of the task result

### DIFF
--- a/src/TaskLog.php
+++ b/src/TaskLog.php
@@ -75,8 +75,10 @@ class TaskLog
      * Unify output to string.
      *
      * @param array|bool|int|string|null $value
+     *
+     * @return string|null
      */
-    protected function setOutput($value): ?string
+    protected function setOutput($value)
     {
         if (is_string($value) || $value === null) {
             return $value;

--- a/src/TaskLog.php
+++ b/src/TaskLog.php
@@ -41,7 +41,9 @@ class TaskLog
     public function __construct(array $data)
     {
         foreach ($data as $key => $value) {
-            if (property_exists($this, $key)) {
+            if ($key === 'output') {
+                $this->output = $this->setOutput($value);
+            } elseif (property_exists($this, $key)) {
                 $this->{$key} = $value;
             }
         }
@@ -67,5 +69,23 @@ class TaskLog
         if (property_exists($this, $key)) {
             return $this->{$key};
         }
+    }
+
+    /**
+     * Unify output to string.
+     *
+     * @param array|bool|int|string|null $value
+     */
+    protected function setOutput($value): ?string
+    {
+        if (is_string($value) || $value === null) {
+            return $value;
+        }
+
+        if (is_array($value)) {
+            return implode(PHP_EOL, $value);
+        }
+
+        return (string) $value;
     }
 }

--- a/src/TaskLog.php
+++ b/src/TaskLog.php
@@ -75,8 +75,6 @@ class TaskLog
      * Unify output to string.
      *
      * @param array<int, string>|bool|int|string|null $value
-     *
-     * @return string|null
      */
     private function setOutput($value): ?string
     {

--- a/src/TaskLog.php
+++ b/src/TaskLog.php
@@ -74,11 +74,11 @@ class TaskLog
     /**
      * Unify output to string.
      *
-     * @param array|bool|int|string|null $value
+     * @param array<int, string>|bool|int|string|null $value
      *
      * @return string|null
      */
-    protected function setOutput($value)
+    private function setOutput($value): ?string
     {
         if (is_string($value) || $value === null) {
             return $value;

--- a/tests/unit/TaskLogTest.php
+++ b/tests/unit/TaskLogTest.php
@@ -28,16 +28,19 @@ final class TaskLogTest extends TestCase
                 '2021-01-21 12:00:00',
                 '2021-01-21 12:00:00',
                 '0.00',
+                ['first item', 'second item'],
             ],
             [
                 '2021-01-21 12:00:00',
                 '2021-01-21 12:00:01',
                 '1.00',
+                true,
             ],
             [
                 '2021-01-21 12:00:00',
                 '2021-01-21 12:05:12',
                 '312.00',
+                null,
             ],
         ];
     }
@@ -45,18 +48,18 @@ final class TaskLogTest extends TestCase
     /**
      * @dataProvider provideDuration
      *
-     * @param mixed $start
-     * @param mixed $end
-     * @param mixed $expected
+     * @param array|bool|int|string|null $output
+     *
+     * @throws Exception
      */
-    public function testDuration($start, $end, $expected)
+    public function testDuration(string $start, string $end, string $expected, $output)
     {
         $start = new Time($start);
         $end   = new Time($end);
 
         $log = new TaskLog([
             'task'     => new Task('closure', static function () {}),
-            'output'   => '',
+            'output'   => $output,
             'runStart' => $start,
             'runEnd'   => $end,
             'error'    => null,


### PR DESCRIPTION
**Description**
This PR fixes a bug where the task result cannot always be logged properly.

Fixes #179

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
