### PR TITLE
Update dependencies to support PHP 8.1 - 8.4

### DIFF
--- a/.github/workflows/deptrac.yml
+++ b/.github/workflows/deptrac.yml
@@ -20,4 +20,4 @@ on:
 
 jobs:
   deptrac:
-    uses: codeigniter4/.github/.github/workflows/deptrac.yml@main
+    uses: codeigniter4/.github/.github/workflows/deptrac.yml@CI46

--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -12,4 +12,4 @@ on:
 
 jobs:
   infection:
-    uses: codeigniter4/.github/.github/workflows/infection.yml@main
+    uses: codeigniter4/.github/.github/workflows/infection.yml@CI46

--- a/.github/workflows/phpcpd.yml
+++ b/.github/workflows/phpcpd.yml
@@ -16,6 +16,6 @@ on:
 
 jobs:
   phpcpd:
-    uses: codeigniter4/.github/.github/workflows/phpcpd.yml@main
+    uses: codeigniter4/.github/.github/workflows/phpcpd.yml@CI46
     with:
       dirs: "src/ tests/"

--- a/.github/workflows/phpcsfixer.yml
+++ b/.github/workflows/phpcsfixer.yml
@@ -16,4 +16,4 @@ on:
 
 jobs:
   phpcsfixer:
-    uses: codeigniter4/.github/.github/workflows/phpcsfixer.yml@main
+    uses: codeigniter4/.github/.github/workflows/phpcsfixer.yml@CI46

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -20,4 +20,4 @@ on:
 
 jobs:
   phpstan:
-    uses: codeigniter4/.github/.github/workflows/phpstan.yml@main
+    uses: codeigniter4/.github/.github/workflows/phpstan.yml@CI46

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -20,4 +20,4 @@ on:
 
 jobs:
   phpunit:
-    uses: codeigniter4/.github/.github/workflows/phpunit.yml@main
+    uses: codeigniter4/.github/.github/workflows/phpunit.yml@CI46

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -20,4 +20,4 @@ on:
 
 jobs:
   psalm:
-    uses: codeigniter4/.github/.github/workflows/psalm.yml@main
+    uses: codeigniter4/.github/.github/workflows/psalm.yml@CI46

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -20,4 +20,4 @@ on:
 
 jobs:
   rector:
-    uses: codeigniter4/.github/.github/workflows/rector.yml@main
+    uses: codeigniter4/.github/.github/workflows/rector.yml@CI46

--- a/.github/workflows/unused.yml
+++ b/.github/workflows/unused.yml
@@ -1,4 +1,4 @@
-name: Rector
+name: Unused
 
 on:
   pull_request:
@@ -18,4 +18,4 @@ on:
 
 jobs:
   rector:
-    uses: codeigniter4/.github/.github/workflows/rector.yml@main
+    uses: codeigniter4/.github/.github/workflows/unused.yml@CI46

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -43,5 +43,5 @@ $options = [
 return Factory::create(new CodeIgniter4(), $overrides, $options)->forLibrary(
     'CodeIgniter Tasks',
     'CodeIgniter Foundation',
-    'admin@codeigniter.com'
+    'admin@codeigniter.com',
 );

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A task scheduler for CodeIgniter 4.
 [![Deptrac](https://github.com/codeigniter4/tasks/actions/workflows/deptrac.yml/badge.svg)](https://github.com/codeigniter4/tasks/actions/workflows/deptrac.yml)
 [![Coverage Status](https://coveralls.io/repos/github/codeigniter4/tasks/badge.svg?branch=develop)](https://coveralls.io/github/codeigniter4/tasks?branch=develop)
 
-![PHP](https://img.shields.io/badge/PHP-%5E7.4-blue)
+![PHP](https://img.shields.io/badge/PHP-%5E8.1-blue)
 ![CodeIgniter](https://img.shields.io/badge/CodeIgniter-%5E4.1-blue)
 ![License](https://img.shields.io/badge/License-MIT-blue)
 

--- a/composer.json
+++ b/composer.json
@@ -18,16 +18,13 @@
     ],
     "homepage": "https://github.com/codeigniter4/tasks",
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "codeigniter4/settings": "^2.0"
     },
     "require-dev": {
-        "codeigniter/coding-standard": "1.7.*",
-        "codeigniter4/devkit": "^1.0",
-        "codeigniter4/framework": "^4.1",
-        "phpunit/phpunit": "^9.6",
-        "rector/rector": "1.2.10"
+        "codeigniter4/devkit": "^1.3",
+        "codeigniter4/framework": "^4.1"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ information, which provides a convenient way of storing settings in the database
 
 ### Requirements
 
-![PHP](https://img.shields.io/badge/PHP-%5E7.4-red)
+![PHP](https://img.shields.io/badge/PHP-%5E8.1-red)
 ![CodeIgniter](https://img.shields.io/badge/CodeIgniter-%5E4.1-red)
 
 ### Quickstart

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,37 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Parameter \#1 \$array of function usort contains unresolvable type\.$#'
+			identifier: argument.unresolvableType
+			count: 1
+			path: src/Commands/Lister.php
+
+		-
+			message: '#^Parameter \#2 \$callback of function usort contains unresolvable type\.$#'
+			identifier: argument.unresolvableType
+			count: 1
+			path: src/Commands/Lister.php
+
+		-
+			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''CodeIgniter\\\\I18n\\\\Time'' and CodeIgniter\\I18n\\Time will always evaluate to true\.$#'
+			identifier: method.alreadyNarrowedType
+			count: 1
+			path: tests/unit/CronExpressionTest.php
+
+		-
+			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''Closure'' and Closure\(\)\: ''Hello'' will always evaluate to true\.$#'
+			identifier: method.alreadyNarrowedType
+			count: 1
+			path: tests/unit/SchedulerTest.php
+
+		-
+			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''CodeIgniter\\\\Tasks\\\\Task'' and CodeIgniter\\Tasks\\Task will always evaluate to true\.$#'
+			identifier: method.alreadyNarrowedType
+			count: 3
+			path: tests/unit/SchedulerTest.php
+
+		-
+			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertSame\(\) with ''Hello'' and ''Hello'' will always evaluate to true\.$#'
+			identifier: method.alreadyNarrowedType
+			count: 1
+			path: tests/unit/SchedulerTest.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,3 +1,5 @@
+includes:
+    - phpstan-baseline.neon
 parameters:
 	tmpDir: build/phpstan
 	level: 5
@@ -7,8 +9,6 @@ parameters:
 	bootstrapFiles:
 		- vendor/codeigniter4/framework/system/Test/bootstrap.php
 	excludePaths:
-		- src/Config/Routes.php
-		- src/Views/*
 	universalObjectCratesClasses:
 		- CodeIgniter\Entity
 		- CodeIgniter\Entity\Entity

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,102 +1,83 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
-		bootstrap="vendor/codeigniter4/framework/system/Test/bootstrap.php"
-		backupGlobals="false"
-		beStrictAboutCoversAnnotation="true"
-		beStrictAboutOutputDuringTests="true"
-		beStrictAboutTodoAnnotatedTests="true"
-		colors="true"
-		convertErrorsToExceptions="true"
-		convertNoticesToExceptions="true"
-		convertWarningsToExceptions="true"
-		executionOrder="random"
-		failOnRisky="true"
-		failOnWarning="true"
-		stopOnError="false"
-		stopOnFailure="false"
-		stopOnIncomplete="false"
-		stopOnSkipped="false"
-		verbose="true">
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         bootstrap="vendor/codeigniter4/framework/system/Test/bootstrap.php"
+         backupGlobals="false"
+         beStrictAboutOutputDuringTests="true"
+         colors="true"
+         executionOrder="random"
+         failOnRisky="true"
+         failOnWarning="true"
+         stopOnError="false"
+         stopOnFailure="false"
+         stopOnIncomplete="false"
+         stopOnSkipped="false"
+         cacheDirectory="build/.phpunit.cache"
+         beStrictAboutCoverageMetadata="true">
 
-	<coverage includeUncoveredFiles="true" processUncoveredFiles="true">
-		<include>
-			<directory suffix=".php">./src/</directory>
-		</include>
-		<exclude>
-			<directory suffix=".php">./src/Config</directory>
-			<directory suffix=".php">./src/Views</directory>
-		</exclude>
-		<report>
-			<clover outputFile="build/phpunit/clover.xml"/>
-			<html outputDirectory="build/phpunit/html"/>
-			<php outputFile="build/phpunit/coverage.serialized"/>
-			<text outputFile="php://stdout" showUncoveredFiles="false"/>
-			<xml outputDirectory="build/phpunit/xml-coverage"/>
-		</report>
-	</coverage>
+    <coverage includeUncoveredFiles="true">
+        <report>
+            <clover outputFile="build/phpunit/clover.xml"/>
+            <html outputDirectory="build/phpunit/html"/>
+            <php outputFile="build/phpunit/coverage.serialized"/>
+            <text outputFile="php://stdout" showUncoveredFiles="false"/>
+            <xml outputDirectory="build/phpunit/xml-coverage"/>
+        </report>
+    </coverage>
 
-	<testsuites>
-		<testsuite name="main">
-			<directory>./tests</directory>
-		</testsuite>
-	</testsuites>
+    <testsuites>
+        <testsuite name="main">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
 
-	<extensions>
-		<extension class="Nexus\PHPUnit\Extension\Tachycardia">
-			<arguments>
-				<array>
-					<element key="timeLimit">
-						<double>0.50</double>
-					</element>
-					<element key="reportable">
-						<integer>30</integer>
-					</element>
-					<element key="precision">
-						<integer>2</integer>
-					</element>
-					<element key="collectBare">
-						<boolean>true</boolean>
-					</element>
-					<element key="tabulate">
-						<boolean>true</boolean>
-					</element>
-				</array>
-			</arguments>
-		</extension>
-	</extensions>
+    <extensions>
+        <bootstrap class="Nexus\PHPUnit\Tachycardia\TachycardiaExtension">
+            <parameter name="time-limit" value="0.50"/>
+            <parameter name="report-count" value="30"/>
+            <parameter name="format" value="table"/>
+        </bootstrap>
+    </extensions>
 
-	<logging>
-		<testdoxHtml outputFile="build/phpunit/testdox.html"/>
-		<testdoxText outputFile="build/phpunit/testdox.txt"/>
-		<junit outputFile="build/phpunit/junit.xml"/>
-	</logging>
+    <logging>
+        <testdoxHtml outputFile="build/phpunit/testdox.html"/>
+        <testdoxText outputFile="build/phpunit/testdox.txt"/>
+        <junit outputFile="build/phpunit/junit.xml"/>
+    </logging>
 
-	<php>
-		<env name="XDEBUG_MODE" value="coverage"/>
-		<server name="app.baseURL" value="https://example.com/"/>
+    <php>
+        <env name="XDEBUG_MODE" value="coverage"/>
+        <server name="app.baseURL" value="https://example.com/"/>
 
-		<!-- Directory containing phpunit.xml -->
-		<const name="HOMEPATH" value="./"/>
+        <!-- Directory containing phpunit.xml -->
+        <const name="HOMEPATH" value="./"/>
 
-		<!-- Directory containing the Paths config file -->
-		<const name="CONFIGPATH" value="./vendor/codeigniter4/framework/app/Config/"/>
+        <!-- Directory containing the Paths config file -->
+        <const name="CONFIGPATH" value="vendor/codeigniter4/framework/app/Config/"/>
 
-		<!-- Directory containing the front controller (index.php) -->
-		<const name="PUBLICPATH" value="./vendor/codeigniter4/framework/public/"/>
+        <!-- Directory containing the front controller (index.php) -->
+        <const name="PUBLICPATH" value="./public/"/>
 
-		<!-- https://getcomposer.org/xdebug -->
-		<env name="COMPOSER_DISABLE_XDEBUG_WARN" value="1"/>
+        <!-- https://getcomposer.org/xdebug -->
+        <env name="COMPOSER_DISABLE_XDEBUG_WARN" value="1"/>
 
-		<!-- Database configuration -->
-		<env name="database.tests.strictOn" value="true"/>
-		<!-- Uncomment to use alternate testing database configuration
-		<env name="database.tests.hostname" value="localhost"/>
-		<env name="database.tests.database" value="tests"/>
-		<env name="database.tests.username" value="tests_user"/>
-		<env name="database.tests.password" value=""/>
-		<env name="database.tests.DBDriver" value="MySQLi"/>
-		<env name="database.tests.DBPrefix" value="tests_"/>
-		-->
-	</php>
+        <!-- Database configuration -->
+        <env name="database.tests.strictOn" value="true"/>
+        <!-- Uncomment to use alternate testing database configuration
+        <env name="database.tests.hostname" value="localhost"/>
+        <env name="database.tests.database" value="tests"/>
+        <env name="database.tests.username" value="tests_user"/>
+        <env name="database.tests.password" value=""/>
+        <env name="database.tests.DBDriver" value="MySQLi"/>
+        <env name="database.tests.DBPrefix" value="tests_"/>
+        -->
+    </php>
+    <source>
+        <include>
+            <directory suffix=".php">./src/</directory>
+        </include>
+        <exclude>
+            <directory suffix=".php">./src/Config</directory>
+        </exclude>
+    </source>
 </phpunit>

--- a/src/Commands/Publish.php
+++ b/src/Commands/Publish.php
@@ -48,7 +48,7 @@ class Publish extends TaskCommand
                     'namespace CodeIgniter\\Tasks\\Config' => 'namespace Config',
                     'use CodeIgniter\\Config\\BaseConfig'  => 'use CodeIgniter\\Tasks\\Config\\Tasks as BaseTasks',
                     'class Tasks extends BaseConfig'       => 'class Tasks extends BaseTasks',
-                ]
+                ],
             );
         }
 

--- a/src/CronExpression.php
+++ b/src/CronExpression.php
@@ -145,7 +145,7 @@ class CronExpression
         assert(ctype_digit($currentTime));
 
         // Handle repeating times (i.e. /5 or */5 for every 5 minutes)
-        if (strpos($time, '/') !== false) {
+        if (str_contains($time, '/')) {
             $period = substr($time, strpos($time, '/') + 1) ?: '';
 
             if ($period === '' || ! ctype_digit($period)) {
@@ -156,7 +156,7 @@ class CronExpression
         }
 
         // Handle ranges (1-5)
-        if (strpos($time, '-') !== false) {
+        if (str_contains($time, '-')) {
             $items         = [];
             [$start, $end] = explode('-', $time);
 

--- a/src/RunResolver.php
+++ b/src/RunResolver.php
@@ -82,19 +82,19 @@ class RunResolver
                     $satisfied = true;
                 }
                 // If the value is a list
-                elseif (strpos($value, ',') !== false) {
+                elseif (str_contains($value, ',')) {
                     if ($this->isInList($nextValue, $value)) {
                         $satisfied = true;
                     }
                 }
                 // If the value is a range
-                elseif (strpos($value, '-') !== false) {
+                elseif (str_contains($value, '-')) {
                     if ($this->isInRange($nextValue, $value)) {
                         $satisfied = true;
                     }
                 }
                 // If the value is an increment
-                elseif (strpos($value, '/') !== false) {
+                elseif (str_contains($value, '/')) {
                     if ($this->isInIncrement($nextValue, $value)) {
                         $satisfied = true;
                     }

--- a/src/RunResolver.php
+++ b/src/RunResolver.php
@@ -207,13 +207,13 @@ class RunResolver
         }
 
         $days = [
-            'sun' => 0,
-            'mon' => 1,
-            'tue' => 2,
-            'wed' => 3,
-            'thu' => 4,
-            'fri' => 5,
-            'sat' => 6,
+            'sun' => '0',
+            'mon' => '1',
+            'tue' => '2',
+            'wed' => '3',
+            'thu' => '4',
+            'fri' => '5',
+            'sat' => '6',
         ];
 
         return str_replace(array_keys($days), array_values($days), $origValue);

--- a/tests/_support/Commands/TasksExample.php
+++ b/tests/_support/Commands/TasksExample.php
@@ -19,12 +19,12 @@ use CodeIgniter\CLI\CLI;
 /**
  * @internal
  */
-final class TasksTest extends BaseCommand
+final class TasksExample extends BaseCommand
 {
     protected $group       = 'Testing';
-    protected $name        = 'tasks:test';
-    protected $description = 'Tests Tasks';
-    protected $usage       = 'tasks:test';
+    protected $name        = 'tasks:example';
+    protected $description = 'Tests Example';
+    protected $usage       = 'tasks:example';
 
     public function run(array $params = [])
     {

--- a/tests/unit/CronExpressionTest.php
+++ b/tests/unit/CronExpressionTest.php
@@ -15,6 +15,7 @@ use CodeIgniter\I18n\Time;
 use CodeIgniter\Tasks\CronExpression;
 use CodeIgniter\Tasks\Exceptions\TasksException;
 use CodeIgniter\Test\CIUnitTestCase as TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * @internal
@@ -140,11 +141,10 @@ final class CronExpressionTest extends TestCase
     }
 
     /**
-     * @dataProvider provideEveryHour
-     *
      * @param mixed $hourTrue
      * @param mixed $hourFalse
      */
+    #[DataProvider('provideEveryHour')]
     public function testEveryHour($hourTrue, $hourFalse)
     {
         $this->cron->testTime($hourTrue);
@@ -234,9 +234,7 @@ final class CronExpressionTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideNextRun
-     */
+    #[DataProvider('provideNextRun')]
     public function testNextRun(string $exp, string $expected)
     {
         $this->cron->testTime('October 5, 2020 8:00 pm');

--- a/tests/unit/TaskLogTest.php
+++ b/tests/unit/TaskLogTest.php
@@ -15,6 +15,7 @@ use CodeIgniter\I18n\Time;
 use CodeIgniter\Tasks\Task;
 use CodeIgniter\Tasks\TaskLog;
 use CodeIgniter\Test\CIUnitTestCase as TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * @internal
@@ -46,12 +47,11 @@ final class TaskLogTest extends TestCase
     }
 
     /**
-     * @dataProvider provideDuration
-     *
      * @param array|bool|int|string|null $output
      *
      * @throws Exception
      */
+    #[DataProvider('provideDuration')]
     public function testDuration(string $start, string $end, string $expected, $output)
     {
         $start = new Time($start);

--- a/tests/unit/TaskTest.php
+++ b/tests/unit/TaskTest.php
@@ -90,13 +90,13 @@ final class TaskTest extends TasksTestCase
 
     public function testCommandRunsCommand()
     {
-        $task = new Task('command', 'tasks:test');
+        $task = new Task('command', 'tasks:example');
 
         $task->run();
 
         $this->assertStringContainsString(
             'Commands can output text.',
-            $this->getBuffer()
+            $this->getBuffer(),
         );
     }
 


### PR DESCRIPTION
**Description**
This PR updates the dependencies and sets the required PHP version to 8.1. We now run tests on all currently supported versions of PHP, the same as the main project.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
