### PR TITLE
fix: don't store a serialized exception on error

### DIFF
--- a/src/TaskRunner.php
+++ b/src/TaskRunner.php
@@ -139,7 +139,13 @@ class TaskRunner
         }
 
         // "unique" name will be returned if one wasn't set
-        $name = $taskLog->task->name;
+        $name  = $taskLog->task->name;
+        $error = null;
+
+        if ($taskLog->error instanceof Throwable) {
+            $error = "Exception: {$taskLog->error->getCode()} - {$taskLog->error->getMessage()}" . PHP_EOL .
+                "file: {$taskLog->error->getFile()}:{$taskLog->error->getLine()}";
+        }
 
         $data = [
             'task'     => $name,
@@ -147,7 +153,7 @@ class TaskRunner
             'start'    => $taskLog->runStart->format('Y-m-d H:i:s'),
             'duration' => $taskLog->duration(),
             'output'   => $taskLog->output ?? null,
-            'error'    => serialize($taskLog->error ?? null),
+            'error'    => $error,
         ];
 
         // Get existing logs

--- a/tests/unit/TaskRunnerTest.php
+++ b/tests/unit/TaskRunnerTest.php
@@ -66,12 +66,59 @@ final class TaskRunnerTest extends TestCase
                 'start'    => date('Y-m-d H:i:s'),
                 'duration' => '0.00',
                 'output'   => null,
-                'error'    => serialize(null),
+                'error'    => null,
             ],
         ];
         $this->seeInDatabase('settings', [
             'class' => 'CodeIgniter\Tasks\Config\Tasks',
             'key'   => 'log-task2',
+            'value' => serialize($expected),
+        ]);
+        $this->dontSeeInDatabase('settings', [
+            'key' => 'log-task1',
+        ]);
+    }
+
+    /**
+     * @throws ReflectionException
+     */
+    public function testRunWithError()
+    {
+        $task1 = (new Task('closure', static function () {
+            echo 'Task 1';
+        }))->daily('12:05am')->named('task1');
+        $task3 = (new Task('closure', static function () {
+            throw new Exception('Example exception in Task 3');
+        }))->daily('12:00am')->named('task3');
+
+        $runner = $this->getRunner([$task1, $task3]);
+
+        ob_start();
+        $runner->withTestTime('12:00am')->run();
+        $output = ob_get_clean();
+
+        // Only task 3 should have run
+        $this->assertSame('', $output);
+
+        // Get info about the exception
+        $reflection = new ReflectionFunction($task3->getAction());
+        $file       = $reflection->getFileName();
+        $line       = $reflection->getStartLine() + 1;
+
+        // Should have logged the stats
+        $expected = [
+            [
+                'task'     => 'task3',
+                'type'     => 'closure',
+                'start'    => date('Y-m-d H:i:s'),
+                'duration' => '0.00',
+                'output'   => null,
+                'error'    => "Exception: 0 - Example exception in Task 3\nfile: {$file}:{$line}",
+            ],
+        ];
+        $this->seeInDatabase('settings', [
+            'class' => 'CodeIgniter\Tasks\Config\Tasks',
+            'key'   => 'log-task3',
             'value' => serialize($expected),
         ]);
         $this->dontSeeInDatabase('settings', [


### PR DESCRIPTION
**Description**
This PR fixes a bug where serialized exceptions could exceed the length of the database field, potentially causing errors or data loss. To prevent this, exceptions will now be stored as simplified text representations, including only essential information such as the message and file location.

Fixes: #187

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
