### PR TITLE
fix: return value for `runQueue()`

### DIFF
--- a/src/Task.php
+++ b/src/Task.php
@@ -315,7 +315,7 @@ class Task
             ]);
         }
 
-        return service('queue')->push(...$queueAction);
+        return service('queue')->push(...$queueAction)->getStatus();
     }
 
     /**

--- a/src/Task.php
+++ b/src/Task.php
@@ -301,6 +301,8 @@ class Task
 
     /**
      * Sends a job to the queue.
+     *
+     * @return bool Status of the queue push
      */
     protected function runQueue()
     {


### PR DESCRIPTION
**Description**
This PR updates how we handle the return value of `runQueue()`. Since queueing now returns a `QueuePushResult` object, we need to call `getStatus()` to retrieve the actual result.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
