### PR TITLE
fix: extend Services class with CodeIgniter's BaseService

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -48,7 +48,6 @@ use Rector\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
 use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
-use Rector\Strict\Rector\If_\BooleanInIfConditionRuleFixerRector;
 use Rector\TypeDeclaration\Rector\Empty_\EmptyOnNullableObjectToInstanceOfRector;
 use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector;
 use Rector\ValueObject\PhpVersion;
@@ -161,7 +160,6 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(StringClassNameToClassConstantRector::class);
     $rectorConfig->rule(PrivatizeFinalClassPropertyRector::class);
     $rectorConfig->rule(CompleteDynamicPropertiesRector::class);
-    $rectorConfig->rule(BooleanInIfConditionRuleFixerRector::class);
     $rectorConfig->rule(SingleInArrayToCompareRector::class);
     $rectorConfig->rule(VersionCompareFuncCallToConstantRector::class);
     $rectorConfig->rule(ExplicitBoolCompareRector::class);

--- a/src/Config/Services.php
+++ b/src/Config/Services.php
@@ -15,9 +15,9 @@ namespace CodeIgniter\Tasks\Config;
 
 use CodeIgniter\Tasks\CronExpression;
 use CodeIgniter\Tasks\Scheduler;
-use Config\Services as BaseServices;
+use CodeIgniter\Config\BaseService;
 
-class Services extends BaseServices
+class Services extends BaseService
 {
     /**
      * Returns the Task Scheduler

--- a/src/Config/Services.php
+++ b/src/Config/Services.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Tasks\Config;
 
+use CodeIgniter\Config\BaseService;
 use CodeIgniter\Tasks\CronExpression;
 use CodeIgniter\Tasks\Scheduler;
-use CodeIgniter\Config\BaseService;
 
 class Services extends BaseService
 {

--- a/src/RunResolver.php
+++ b/src/RunResolver.php
@@ -151,7 +151,7 @@ class RunResolver
     {
         $list = explode(',', $list);
 
-        return in_array(trim($value), $list, true);
+        return in_array(trim((string) $value), $list, true);
     }
 
     /**

--- a/src/Task.php
+++ b/src/Task.php
@@ -365,7 +365,7 @@ class Task
      */
     public function __get(string $key)
     {
-        if ($key === 'name' && empty($this->name)) {
+        if ($key === 'name' && (! isset($this->name) || ($this->name === ''))) {
             return $this->buildName();
         }
 


### PR DESCRIPTION
**Description**
Hi, I stumbled on this issue when using [phpstan-codeigniter](https://github.com/CodeIgniter/phpstan-codeigniter):
`Internal error: Services factory class "CodeIgniter\Tasks\Config\Services" does not extend CodeIgniter\Config\BaseService.`

Tasks services don't extend the right `CodeIgniter\Config\BaseService` class as they should.

This PR fixes it. Thank you!
