### PR TITLE
chore: update workflow to include PHP 8.5

### DIFF
--- a/.github/workflows/deptrac.yml
+++ b/.github/workflows/deptrac.yml
@@ -20,4 +20,4 @@ on:
 
 jobs:
   deptrac:
-    uses: codeigniter4/.github/.github/workflows/deptrac.yml@CI46
+    uses: codeigniter4/.github/.github/workflows/deptrac.yml@CI47

--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -12,4 +12,4 @@ on:
 
 jobs:
   infection:
-    uses: codeigniter4/.github/.github/workflows/infection.yml@CI46
+    uses: codeigniter4/.github/.github/workflows/infection.yml@CI47

--- a/.github/workflows/phpcpd.yml
+++ b/.github/workflows/phpcpd.yml
@@ -16,6 +16,6 @@ on:
 
 jobs:
   phpcpd:
-    uses: codeigniter4/.github/.github/workflows/phpcpd.yml@CI46
+    uses: codeigniter4/.github/.github/workflows/phpcpd.yml@CI47
     with:
       dirs: "src/ tests/"

--- a/.github/workflows/phpcsfixer.yml
+++ b/.github/workflows/phpcsfixer.yml
@@ -16,4 +16,4 @@ on:
 
 jobs:
   phpcsfixer:
-    uses: codeigniter4/.github/.github/workflows/phpcsfixer.yml@CI46
+    uses: codeigniter4/.github/.github/workflows/phpcsfixer.yml@CI47

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -20,4 +20,4 @@ on:
 
 jobs:
   phpstan:
-    uses: codeigniter4/.github/.github/workflows/phpstan.yml@CI46
+    uses: codeigniter4/.github/.github/workflows/phpstan.yml@CI47

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -22,7 +22,7 @@ jobs:
   phpunit:
     strategy:
       matrix:
-        php-version: ['8.1', '8.2', '8.3', '8.4']
+        php-version: ['8.2', '8.3', '8.4', '8.5']
         db-platform: ['MySQLi', 'SQLite3']
         mysql-version: ['8.0']
         dependencies: ['highest']
@@ -44,7 +44,7 @@ jobs:
             db-platform: OCI8
             mysql-version: '8.0'
 
-    uses: codeigniter4/.github/.github/workflows/phpunit.yml@CI46
+    uses: codeigniter4/.github/.github/workflows/phpunit.yml@CI47
     with:
       php-version: ${{ matrix.php-version }}
       db-platform: ${{ matrix.db-platform }}

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -20,4 +20,4 @@ on:
 
 jobs:
   psalm:
-    uses: codeigniter4/.github/.github/workflows/psalm.yml@CI46
+    uses: codeigniter4/.github/.github/workflows/psalm.yml@CI47

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -20,4 +20,4 @@ on:
 
 jobs:
   rector:
-    uses: codeigniter4/.github/.github/workflows/rector.yml@CI46
+    uses: codeigniter4/.github/.github/workflows/rector.yml@CI47

--- a/.github/workflows/unused.yml
+++ b/.github/workflows/unused.yml
@@ -18,4 +18,4 @@ on:
 
 jobs:
   rector:
-    uses: codeigniter4/.github/.github/workflows/unused.yml@CI46
+    uses: codeigniter4/.github/.github/workflows/unused.yml@CI47

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ A task scheduler for CodeIgniter 4.
 [![Deptrac](https://github.com/codeigniter4/tasks/actions/workflows/deptrac.yml/badge.svg)](https://github.com/codeigniter4/tasks/actions/workflows/deptrac.yml)
 [![Coverage Status](https://coveralls.io/repos/github/codeigniter4/tasks/badge.svg?branch=develop)](https://coveralls.io/github/codeigniter4/tasks?branch=develop)
 
-![PHP](https://img.shields.io/badge/PHP-%5E8.1-blue)
-![CodeIgniter](https://img.shields.io/badge/CodeIgniter-%5E4.1-blue)
+![PHP](https://img.shields.io/badge/PHP-%5E8.2-blue)
+![CodeIgniter](https://img.shields.io/badge/CodeIgniter-%5E4.3-blue)
 ![License](https://img.shields.io/badge/License-MIT-blue)
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,14 @@
     ],
     "homepage": "https://github.com/codeigniter4/tasks",
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "ext-json": "*",
         "codeigniter4/settings": "^2.0",
         "codeigniter4/queue": "dev-develop"
     },
     "require-dev": {
         "codeigniter4/devkit": "^1.3",
-        "codeigniter4/framework": "^4.1"
+        "codeigniter4/framework": "^4.3"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,8 +11,8 @@ information, which provides a convenient way of storing settings in the database
 
 ### Requirements
 
-![PHP](https://img.shields.io/badge/PHP-%5E8.1-red)
-![CodeIgniter](https://img.shields.io/badge/CodeIgniter-%5E4.1-red)
+![PHP](https://img.shields.io/badge/PHP-%5E8.2-red)
+![CodeIgniter](https://img.shields.io/badge/CodeIgniter-%5E4.3-red)
 
 ### Quickstart
 

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    phpVersion="8.1"
+    phpVersion="8.2"
     errorLevel="7"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/rector.php
+++ b/rector.php
@@ -56,7 +56,7 @@ use Rector\ValueObject\PhpVersion;
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([
         SetList::DEAD_CODE,
-        LevelSetList::UP_TO_PHP_81,
+        LevelSetList::UP_TO_PHP_82,
         PHPUnitSetList::PHPUNIT_CODE_QUALITY,
         PHPUnitSetList::PHPUNIT_100,
     ]);
@@ -90,7 +90,7 @@ return static function (RectorConfig $rectorConfig): void {
     }
 
     // Set the target version for refactoring
-    $rectorConfig->phpVersion(PhpVersion::PHP_81);
+    $rectorConfig->phpVersion(PhpVersion::PHP_82);
 
     // Auto-import fully qualified class names
     $rectorConfig->importNames();

--- a/src/CronExpression.php
+++ b/src/CronExpression.php
@@ -39,8 +39,6 @@ class CronExpression
      * on construct
      *
      * @param string $timezone The global timezone for all tasks
-     *
-     * @return void
      */
     public function __construct(?string $timezone = null)
     {


### PR DESCRIPTION
**Description**
This PR updates workflows to include PHP 8.5. We also set the minimum PHP version to 8.2.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
