### PR TITLE
fix: change queue dependency from dev-develop to ^1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": "^8.2",
         "ext-json": "*",
         "codeigniter4/settings": "^2.0",
-        "codeigniter4/queue": "dev-develop"
+        "codeigniter4/queue": "^1.0"
     },
     "require-dev": {
         "codeigniter4/devkit": "^1.3",


### PR DESCRIPTION
**Description**
This PR fixes installation failures in projects using Composer's default stable minimum-stability settings.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
